### PR TITLE
Add nbformat for requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ lightgbm>=4.0.0
 matplotlib>=3.7.2
 methodtools>=0.4.7
 mlflow>=2.5.0
+nbformat>=4.2.0
 numpy>=1.23.5
 opencv-python>=4.8.0.74
 openpyxl>=3.1.2

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -32,6 +32,7 @@ def test_noisy_features() -> None:
         exp_manager.opt_metric,
     )
     assert len(interp.get_noisy_features()) > -1
+    interp.plot_confusion_matrix() 
 
 
 def test_no_shap() -> None:


### PR DESCRIPTION
Add nbformat for the requirements. 
This is a missing dependency of plotly, described here: https://github.com/plotly/plotly.py/issues/2875
